### PR TITLE
added framedef to handle dataframes

### DIFF
--- a/packages/vgplot/python/api/__init__.py
+++ b/packages/vgplot/python/api/__init__.py
@@ -1,5 +1,5 @@
 from .spec import meta, spec, Spec
-from .data import parquet, csv, spatial, table, data
+from .data import parquet, csv, spatial, table, data, FrameDef
 from .params import param, selection
 from .encodings import (
     sql,
@@ -23,6 +23,7 @@ from .encodings import (
 )
 from .plot import (
     plot,
+    PlotData,
     source,
     mark,
     directive,
@@ -328,11 +329,13 @@ __all__ = [
     "spatial",
     "table",
     "data",
+    "FrameDef",
     # params
     "param",
     "selection",
     # plot core
     "plot",
+    "PlotData",
     "source",
     "mark",
     "directive",

--- a/packages/vgplot/python/api/data.py
+++ b/packages/vgplot/python/api/data.py
@@ -4,6 +4,18 @@ from dataclasses import dataclass
 from typing import Any, Dict
 
 
+FRAME_MODULES = frozenset({"pandas", "polars", "pyarrow"})
+
+
+def _is_frame_like(obj: Any) -> bool:
+    return type(obj).__module__.split(".")[0] in FRAME_MODULES
+
+
+class FrameDef:
+    def __init__(self, frame: Any) -> None:
+        self.frame = frame
+
+
 @dataclass
 class DataDef:
     payload: Dict[str, Any]

--- a/packages/vgplot/python/api/plot.py
+++ b/packages/vgplot/python/api/plot.py
@@ -1,11 +1,29 @@
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
 from .util import camelize, omit_none
 from .params import _ParamBase
-from .data import DataDef
+from .data import DataDef, FrameDef, _is_frame_like
+
+
+class PlotData(dict):
+    """Return type of vg.plot(): a pure-JSON spec dict with attached dataframes.
+
+    The dict content is a clean, JSON-serializable spec (all dataframe references
+    resolved to {"from": "name"}). Dataframes are stored separately in .frames
+    and never embedded inside the dict.
+    """
+
+    def __init__(self, spec_dict: Dict[str, Any], frames: Dict[str, Any] | None = None) -> None:
+        super().__init__(spec_dict)
+        self.frames: Dict[str, Any] = frames or {}
+
+    def spec(self) -> Dict[str, Any]:
+        """Returns a plain dict copy — suitable for MosaicWidget(spec=...) or JSON."""
+        return dict(self)
 
 
 class FromRef:
@@ -36,7 +54,11 @@ class Mark:
     data: Optional[Any] = None
     enc: Optional[Dict[str, Any]] = None
 
-    def to_dict(self, param_names: Dict[str, str] | None = None) -> Dict[str, Any]:
+    def __post_init__(self) -> None:
+        if self.data is not None and _is_frame_like(self.data):
+            self.data = FrameDef(self.data)
+
+    def to_dict(self, param_names: Dict[str, str] | None = None, data_names: Dict[int, str] | None = None) -> Dict[str, Any]:
         payload: Dict[str, Any] = {"mark": self.mark}
         enc = dict(self.enc or {})
         _DATA_OPTS = {"filter_by": "filterBy", "optimize": "optimize"}
@@ -50,18 +72,14 @@ class Mark:
                 data_dict = self.data
             if data_opts and isinstance(data_dict, dict):
                 data_dict = {**data_dict, **data_opts}
-            payload["data"] = encode_value(data_dict, param_names)
+            payload["data"] = encode_value(data_dict, param_names, data_names)
         for k, v in enc.items():
             payload[camelize(k)] = encode_value(v, param_names)
         return payload
 
 
-def encode_value(
-    v: Any,
-    param_names: Dict[str, str] | None = None,
-    data_names: Dict[int, str] | None = None,
-) -> Any:
-    if isinstance(v, DataDef):
+def encode_value(v: Any, param_names: Dict[str, str] | None = None, data_names: Dict[int, str] | None = None) -> Any:
+    if isinstance(v, (DataDef, FrameDef)):
         if data_names and id(v) in data_names:
             return {"from": data_names[id(v)]}
         return v
@@ -83,12 +101,31 @@ def encode_value(
 
 def plot(
     *items: Union[Mark, Directive], param_names: Dict[str, str] | None = None
-) -> Dict[str, Any]:
+) -> PlotData:
+    caller_locals = inspect.currentframe().f_back.f_locals
+
+    # Collect FrameDef objects from all Mark items and name them via caller locals
+    frame_names: Dict[int, str] = {}
+    frames: Dict[str, Any] = {}
+    seen: set = set()
+    for item in items:
+        if isinstance(item, Mark) and isinstance(item.data, FrameDef):
+            fd = item.data
+            if id(fd) in seen:
+                continue
+            seen.add(id(fd))
+            name = next(
+                (k for k, v in caller_locals.items() if v is fd.frame and not k.startswith("_")),
+                f"_frame{len(frame_names)}",
+            )
+            frame_names[id(fd)] = name
+            frames[name] = fd.frame
+
     marks: List[Dict[str, Any]] = []
     directives: Dict[str, Any] = {}
     for item in items:
         if isinstance(item, Mark):
-            marks.append(item.to_dict(param_names))
+            marks.append(item.to_dict(param_names=param_names, data_names=frame_names))
         elif isinstance(item, Directive):
             k, v = item.to_kv()
             directives[k] = encode_value(v, param_names)
@@ -96,9 +133,9 @@ def plot(
             marks.append({k: encode_value(v, param_names) for k, v in item.items()})
         else:
             raise TypeError(f"Unsupported plot item: {item}")
-    root: Dict[str, Any] = {"plot": marks}
-    root.update(directives)
-    return root
+    spec_dict: Dict[str, Any] = {"plot": marks}
+    spec_dict.update(directives)
+    return PlotData(spec_dict, frames)
 
 
 def directive(key: str, value: Any) -> Directive:
@@ -258,12 +295,30 @@ def _encode_component(
 
 
 # Layout helpers
-def vconcat(*items: Any, param_names: Dict[str, str] | None = None) -> Dict[str, Any]:
-    return {"vconcat": [_encode_component(i, param_names) for i in items]}
+def vconcat(*items: Any, param_names: Dict[str, str] | None = None) -> Union[Dict[str, Any], PlotData]:
+    child_specs: List[Any] = []
+    all_frames: Dict[str, Any] = {}
+    for item in items:
+        if isinstance(item, PlotData):
+            all_frames.update(item.frames)
+            child_specs.append(_encode_component(item.spec(), param_names))
+        else:
+            child_specs.append(_encode_component(item, param_names))
+    result: Dict[str, Any] = {"vconcat": child_specs}
+    return PlotData(result, all_frames) if all_frames else result
 
 
-def hconcat(*items: Any, param_names: Dict[str, str] | None = None) -> Dict[str, Any]:
-    return {"hconcat": [_encode_component(i, param_names) for i in items]}
+def hconcat(*items: Any, param_names: Dict[str, str] | None = None) -> Union[Dict[str, Any], PlotData]:
+    child_specs: List[Any] = []
+    all_frames: Dict[str, Any] = {}
+    for item in items:
+        if isinstance(item, PlotData):
+            all_frames.update(item.frames)
+            child_specs.append(_encode_component(item.spec(), param_names))
+        else:
+            child_specs.append(_encode_component(item, param_names))
+    result: Dict[str, Any] = {"hconcat": child_specs}
+    return PlotData(result, all_frames) if all_frames else result
 
 
 def hspace(px: int) -> Dict[str, Any]:

--- a/packages/vgplot/python/api/spec.py
+++ b/packages/vgplot/python/api/spec.py
@@ -161,12 +161,19 @@ class Spec:
     def to_json(self, **kwargs: Any) -> str:
         return json.dumps(self.to_dict(), **kwargs)
 
+    @property
+    def frames(self) -> dict:
+        #Dataframes from PlotData views are passed separately to MosaicWidget.
+        if hasattr(self.view, "frames"):
+            return self.view.frames
+        return {}
+
     def _repr_mimebundle_(self, **kwargs):
         try:
             from mosaic_widget import MosaicWidget
         except ImportError:
             return {"text/plain": repr(self)}
-        widget = MosaicWidget(self.to_dict())
+        widget = MosaicWidget(self.to_dict(), data=self.frames)
         return widget._repr_mimebundle_(**kwargs)
 
     def show(self, con=None, data=None):
@@ -175,7 +182,7 @@ class Spec:
             from IPython.display import display
         except ImportError as e:
             raise ImportError("pip install mosaic-widget") from e
-        widget = MosaicWidget(self.to_dict(), con=con, data=data)
+        widget = MosaicWidget(self.to_dict(), con=con, data={**self.frames, **(data or {})})
         display(widget)
 
 

--- a/packages/vgplot/widget/mosaic_widget/__init__.py
+++ b/packages/vgplot/widget/mosaic_widget/__init__.py
@@ -46,7 +46,8 @@ class MosaicWidget(anywidget.AnyWidget):
         """Create a Mosaic widget.
 
         Args:
-            spec (dict, optional): The initial Mosaic specification. Defaults to {}.
+            spec (dict, optional): The initial Mosaic specification, or a PlotData
+                object returned by vg.plot(). Defaults to {}.
             con (connection, optional): A DuckDB connection.
                 Defaults to duckdb.connect().
             data (dict, optional): DataFrames/Arrow objects to "register" with DuckDB.
@@ -61,10 +62,18 @@ class MosaicWidget(anywidget.AnyWidget):
         if con is None:
             con = duckdb.connect()
 
+        # If spec is a PlotData (vg.plot() result), extract frames and get clean spec dict
+        frames_from_view: dict = {}
+        if hasattr(spec, "frames") and hasattr(spec, "spec"):
+            frames_from_view = spec.frames
+            spec = spec.spec()
+
+        all_data = {**frames_from_view, **data}
+
         super().__init__(*args, **kwargs)
         self.spec = spec
         self.con = con
-        for name, df in data.items():
+        for name, df in all_data.items():
             self.con.register(name, frame_to_duckdb_registrable(df))
         self.on_msg(self._handle_custom_msg)
 


### PR DESCRIPTION
vg.plot() returns a PlotData which is a dict containing the clean JSON spec (with DataFrames already resolved to {"from": "name"} references) and a .frames dict holding the actual DataFrame objects. When vg.spec() is called, it detects the PlotData view and copies those frames into Spec.frames. At show() time, Spec passes both the spec dict and the frames to MosaicWidget, which registers each DataFrame in DuckDB as a virtual table under its variable name. The JS frontend then queries DuckDB by that name so that the raw data never touches the spec as opposed to serially adding the dataframe to the view itself. 